### PR TITLE
FIX:修复Gemini_base_url 不能自定义

### DIFF
--- a/.claude/scripts/gemini-wrapper
+++ b/.claude/scripts/gemini-wrapper
@@ -52,6 +52,12 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+# Respect custom Gemini base URL
+if [[ -n "$GOOGLE_GEMINI_BASE_URL" ]]; then
+    echo -e "${GREEN}🌐 Using custom Gemini base URL: $GOOGLE_GEMINI_BASE_URL${NC}" >&2
+    export GOOGLE_GEMINI_BASE_URL
+fi
+
 # Function to count tokens (approximate: chars/4) - optimized version
 count_tokens() {
     local total_chars=0


### PR DESCRIPTION
BUG:使用第三方自定义的API，如newapi时，该脚本无法自动将baseurl 替换成第三方的url，导致send request fail。
FIX:[Gemini##2899](https://github.com/google-gemini/gemini-cli/pull/2899)参考官方issue，添加GOOGLE_GEMINI_BASE_URL环境变量

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom Gemini base URL via the GOOGLE_GEMINI_BASE_URL environment variable, allowing routing requests through self-hosted or proxy endpoints.
  * When set, the tool now confirms the active base URL in stderr for transparency. Defaults remain unchanged for standard setups. This improves deployment flexibility across different network environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->