### PR TITLE
Check for .active identifier in workflow files

### DIFF
--- a/COMMAND_SPEC.md
+++ b/COMMAND_SPEC.md
@@ -180,7 +180,7 @@ Commands for creating, listing, and managing workflow sessions.
 - **Syntax**: `/workflow:session:complete [--detailed]`
 - **Parameters**:
   - `--detailed` (Flag): Shows a more detailed completion summary.
-- **Responsibilities**: Marks the currently active session as "completed", records timestamps, and removes the `.active-*` marker file.
+- **Responsibilities**: Marks the currently active session as "completed", records timestamps, and moves the session from `.workflow/active/` to `.workflow/archives/`.
 - **Agent Calls**: None.
 - **Example**:
   ```bash

--- a/WORKFLOW_DIAGRAMS.md
+++ b/WORKFLOW_DIAGRAMS.md
@@ -14,9 +14,10 @@ graph TB
     end
 
     subgraph "Session Management"
-        MARKER[".active-session marker"]
         SESSION["workflow-session.json"]
         WDIR[".workflow/ directories"]
+        ACTIVE_DIR[".workflow/active/"]
+        ARCHIVE_DIR[".workflow/archives/"]
     end
 
     subgraph "Task System"
@@ -124,9 +125,7 @@ stateDiagram-v2
     CreateStructure --> CreateJSON: Create workflow-session.json
     CreateJSON --> CreatePlan: Create IMPL_PLAN.md
     CreatePlan --> CreateTasks: Create .task/ directory
-    CreateTasks --> SetActive: touch .active-session-name
-
-    SetActive --> Active: Session Ready
+    CreateTasks --> Active: Session Ready in .workflow/active/
 
     Active --> Paused: Switch to Another Session
     Active --> Working: Execute Tasks


### PR DESCRIPTION
Remove outdated references to .active-session marker files that are no longer used in the workflow implementation. The system now uses directory-based session management where active sessions are identified by their location in .workflow/active/ directory.

Changes:
- WORKFLOW_DIAGRAMS.md: Replace .active-session marker with actual directory structure
- COMMAND_SPEC.md: Update session:complete description to reflect directory-based archival

The .archiving marker is still valid and used for transactional session completion.