### PR TITLE
fix(core): replace require() with ESM imports in cache-manager

### DIFF
--- a/ccw/src/core/cache-manager.ts
+++ b/ccw/src/core/cache-manager.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync, statSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, statSync, unlinkSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { StoragePaths, ensureStorageDir } from '../config/storage-paths.js';
 
@@ -118,8 +118,7 @@ export class CacheManager<T> {
   invalidate(): void {
     try {
       if (existsSync(this.cacheFile)) {
-        const fs = require('fs');
-        fs.unlinkSync(this.cacheFile);
+        unlinkSync(this.cacheFile);
       }
     } catch (err) {
       console.warn(`Cache invalidation error for ${this.cacheFile}:`, (err as Error).message);
@@ -180,8 +179,7 @@ export class CacheManager<T> {
     if (depth > 3) return; // Limit recursion depth
 
     try {
-      const fs = require('fs');
-      const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+      const entries = readdirSync(dirPath, { withFileTypes: true });
 
       for (const entry of entries) {
         const fullPath = join(dirPath, entry.name);


### PR DESCRIPTION
Remove CommonJS require() calls that caused \"require is not defined\" errors when scanning .workflow directories in ESM context.

Changes:
- Add unlinkSync and readdirSync to fs import statement
- Replace require('fs').unlinkSync() with direct unlinkSync() call
- Replace require('fs').readdirSync() with direct readdirSync() call

Fixes: Cannot scan directory .workflow/active: require is not defined

File: ccw/src/core/cache-manager.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved cache management system performance and optimized module dependencies for reduced bundle size.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->