### PR TITLE
fix(cli): correct package.json path resolution

### DIFF
--- a/ccw/src/cli.ts
+++ b/ccw/src/cli.ts
@@ -31,7 +31,7 @@ interface PackageInfo {
  * @returns Package info with version
  */
 function loadPackageInfo(): PackageInfo {
-  const pkgPath = join(__dirname, '../package.json');
+  const pkgPath = join(__dirname, '../../package.json');
 
   try {
     if (!existsSync(pkgPath)) {


### PR DESCRIPTION
Fix package.json lookup path from '../package.json' to '../../package.json' to correctly resolve from ccw/dist/ to project root directory.

The previous path assumed package.json was in ccw/, but it's actually in the project root. This caused \"Fatal Error: package.json not found\" when running ccw commands.

Resolves path: ccw/dist/cli.js -> ../../package.json -> /package.json

File: ccw/src/cli.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the package metadata loading path in the CLI, improving error handling when package configuration is missing or invalid.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->