### PR TITLE
fix(hooks): correct cross-platform path handling in getProjectSettingsPath

### DIFF
--- a/ccw/src/core/routes/hooks-routes.ts
+++ b/ccw/src/core/routes/hooks-routes.ts
@@ -31,8 +31,8 @@ const GLOBAL_SETTINGS_PATH = join(homedir(), '.claude', 'settings.json');
  * @returns {string}
  */
 function getProjectSettingsPath(projectPath) {
-  const normalizedPath = projectPath.replace(/\//g, '\\').replace(/^\\([a-zA-Z])\\/, '$1:\\');
-  return join(normalizedPath, '.claude', 'settings.json');
+  // path.join automatically handles cross-platform path separators
+  return join(projectPath, '.claude', 'settings.json');
 }
 
 /**

--- a/ccw/src/core/routes/mcp-routes.ts
+++ b/ccw/src/core/routes/mcp-routes.ts
@@ -1000,8 +1000,8 @@ function writeSettingsFile(filePath, settings) {
  * @returns {string}
  */
 function getProjectSettingsPath(projectPath) {
-  const normalizedPath = projectPath.replace(/\//g, '\\').replace(/^\\([a-zA-Z])\\/, '$1:\\');
-  return join(normalizedPath, '.claude', 'settings.json');
+  // path.join automatically handles cross-platform path separators
+  return join(projectPath, '.claude', 'settings.json');
 }
 
 // ========================================


### PR DESCRIPTION
Remove incorrect path separator conversion that caused directory creation issues on Linux/WSL platforms. The function was converting forward slashes to backslashes, which are treated as literal filename characters on Unix systems rather than path separators.

Changes:
- Remove manual path normalization in getProjectSettingsPath()
- Rely on Node.js path.join() for cross-platform compatibility
- Fix affects both hooks-routes.ts and mcp-routes.ts

Impact:
- Linux/WSL: Fixes incorrect directory creation
- Windows: No behavior change, maintains correct functionality

Fixes project-level hook settings being saved to wrong location when using Dashboard frontend on Linux/WSL systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved cross-platform file path handling for project settings files to ensure consistent behavior across different operating systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->