### PR TITLE
fix: resolve CodexLens installation failure with NPM global install

### DIFF
--- a/ccw/src/tools/codex-lens.ts
+++ b/ccw/src/tools/codex-lens.ts
@@ -83,8 +83,8 @@ function findLocalPackagePath(packageName: string): string | null {
     possiblePaths.push(join(cwdParent, packageName));
   }
 
+  // First pass: prefer non-node_modules paths (development environment)
   for (const localPath of possiblePaths) {
-    // Skip paths inside node_modules
     if (isInsideNodeModules(localPath)) {
       continue;
     }
@@ -94,8 +94,12 @@ function findLocalPackagePath(packageName: string): string | null {
     }
   }
 
-  if (!isDevEnvironment()) {
-    console.log(`[CodexLens] Running from node_modules - will try PyPI for ${packageName}`);
+  // Second pass: allow node_modules paths (NPM global install)
+  for (const localPath of possiblePaths) {
+    if (existsSync(join(localPath, 'pyproject.toml'))) {
+      console.log(`[CodexLens] Found ${packageName} in node_modules at: ${localPath}`);
+      return localPath;
+    }
   }
 
   return null;


### PR DESCRIPTION
- Implement two-pass search strategy for codex-lens path detection
- First pass: prefer non-node_modules paths (development environment)
- Second pass: allow node_modules paths (NPM global install)
- Fixes CodexLens installation for all NPM global install users
- No breaking changes, maintains backward compatibility

Resolves issue where NPM global install users could not install CodexLens because the code rejected paths containing /node_modules/, which is the only valid location for codex-lens in NPM installations.

Tested on macOS with Node.js v22.18.0 via NPM global install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of local development packages, including those installed in node_modules directories, for more reliable package discovery across different installation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->