### PR TITLE
Fix missing ccw install step in installation documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,6 +14,22 @@ Installation guide for Claude Code Agent workflow coordination and distributed m
 npm install -g claude-code-workflow
 ```
 
+### Complete Installation
+
+After installing the npm package, you need to run the installation command to set up workflows, scripts, and templates:
+
+```bash
+# Install CCW system files (workflows, scripts, templates)
+ccw install
+```
+
+The `ccw install` command will:
+- Install workflow definitions to `~/.claude/workflows/`
+- Install utility scripts to `~/.claude/scripts/`
+- Install prompt templates to `~/.claude/templates/`
+- Install skill definitions to `~/.codex/skills/`
+- Configure shell integration (optional)
+
 ### Verify Installation
 
 ```bash

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -14,6 +14,22 @@ Claude Code Agent 工作流协调和分布式内存系统的安装指南。
 npm install -g claude-code-workflow
 ```
 
+### 完成安装
+
+安装 npm 包后，需要运行安装命令来设置工作流、脚本和模板：
+
+```bash
+# 安装 CCW 系统文件（工作流、脚本、模板）
+ccw install
+```
+
+`ccw install` 命令将会：
+- 安装工作流定义到 `~/.claude/workflows/`
+- 安装实用脚本到 `~/.claude/scripts/`
+- 安装提示模板到 `~/.claude/templates/`
+- 安装技能定义到 `~/.codex/skills/`
+- 配置 shell 集成（可选）
+
 ### 验证安装
 
 ```bash


### PR DESCRIPTION
- Added the crucial `ccw install` step after npm installation in both English (INSTALL.md) and Chinese (INSTALL_CN.md) documentation
- Included detailed explanation of what ccw install does:
  * Installs workflows, scripts, templates to ~/.claude/
  * Installs skill definitions to ~/.codex/
  * Configures shell integration (optional)

This step is essential for the complete installation of CCW system files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide with instructions for the ccw install command, documenting file installation locations and optional shell integration setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->