### PR TITLE
fix: add items schema for session_manager dirs array

### DIFF
--- a/ccw/src/tools/session-manager.ts
+++ b/ccw/src/tools/session-manager.ts
@@ -1120,6 +1120,7 @@ export const schema: ToolSchema = {
       },
       dirs: {
         type: 'array',
+        items: { type: 'string' },
         description: 'Directory paths to create for mkdir operation',
       },
       update_status: {


### PR DESCRIPTION
## Summary
- add the missing `items` definition for the `dirs` array in `session_manager`
- fix Claude Code / MCP schema validation failures when the tool is registered
- keep the change minimal and source-only

## Test plan
- [x] inspect `ccw/src/tools/session-manager.ts` and confirm `dirs` now includes `items: { type: 'string' }`
- [x] verify the installed build failure locally matched the same missing schema field
- [ ] publish a new package version and confirm `/zcf:init-project` no longer fails at tool registration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for directory configuration to ensure all array entries are properly validated as strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->